### PR TITLE
Enable nbextensions, in addition to installing them

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 971a37b58a8f1a26e7b17eacb091879b5f1646f5097b717626436a266a178d33
 
 build:
-  number: 1
+  number: 2
   script: python -m pip install --no-deps .
   entry_points:
     - nbgrader = nbgrader.apps.nbgraderapp:main

--- a/recipe/post-link.bat
+++ b/recipe/post-link.bat
@@ -1,4 +1,5 @@
 @echo off
 
-"%PREFIX%\Scripts\jupyter-nbextension.exe" install nbgrader --py --sys-prefix >> "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-nbextension.exe" install nbgrader --py --sys-prefix --overwrite >> "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-nbextension.exe" enable nbgrader --py --sys-prefix >> "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
 "%PREFIX%\Scripts\jupyter-serverextension.exe" enable nbgrader --py --sys-prefix >> "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,2 +1,3 @@
-"${PREFIX}/bin/jupyter-nbextension" install nbgrader --py --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1
+"${PREFIX}/bin/jupyter-nbextension" install nbgrader --py --sys-prefix --overwrite >> "${PREFIX}/.messages.txt" 2>&1
+"${PREFIX}/bin/jupyter-nbextension" enable nbgrader --py --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1
 "${PREFIX}/bin/jupyter-serverextension" enable nbgrader --py --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,4 +1,5 @@
 @echo off
 
+"%PREFIX%\Scripts\jupyter-nbextension.exe" disable nbgrader --py --sys-prefix >> "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
 "%PREFIX%\Scripts\jupyter-nbextension.exe" uninstall nbgrader --py --sys-prefix >> "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1
 "%PREFIX%\Scripts\jupyter-serverextension.exe" disable nbgrader --py --sys-prefix >> "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,2 +1,3 @@
+"${PREFIX}/bin/jupyter-nbextension" disable nbgrader --py --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1
 "${PREFIX}/bin/jupyter-nbextension" uninstall nbgrader --py --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1
 "${PREFIX}/bin/jupyter-serverextension" disable nbgrader --py --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1


### PR DESCRIPTION
#13 accidentally removed the line enabling the nbextensions, causing installation problems: https://github.com/jupyter/nbgrader/issues/854

This adds back in the lines which enable them, in addition to installing them and enabling the server extensions.