### PR TITLE
Pins jupyterlab<3.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
 
 build:
   noarch: python
-  number: 0
-  script: 
+  number: 1
+  script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - nbgrader = nbgrader.apps.nbgraderapp:main
@@ -31,7 +31,7 @@ requirements:
     - jsonschema >=3
     - jupyter_client <8
     - jupyter_server >=1.12
-    - jupyterlab <4
+    - jupyterlab <3.6
     - jupyterlab_server
     - nbclassic <0.4.0
     - nbclient >=0.6.1
@@ -42,7 +42,7 @@ requirements:
     - requests >=2.26
     - sqlalchemy >=1.4,<2
     - traitlets <5.2.0
- 
+
 test:
   imports:
     - nbgrader


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

This PR pins `jupyterlab<3.6`.

Since version 3.6, jupyterlab brings the `traitlets>=5.3` dependency, probably because of `jupyter_events` dependency (not sure about that).
This dependency breaks the installation, since `nbgrader 0.8.1` requires `traitlets<5.2`

This has been discussed in https://github.com/jupyter/nbgrader/issues/1733